### PR TITLE
Studio: added pipeline configuration scripts

### DIFF
--- a/.pipelines/azure-pipelines/DecideTemplatesToPack.ps1
+++ b/.pipelines/azure-pipelines/DecideTemplatesToPack.ps1
@@ -1,0 +1,60 @@
+param(
+    [string] $shouldGetTemplatesFromConfig = $false,
+
+    [string] $templatesConfig = "$PSScriptRoot\templates.config",
+
+    [string] $outputDirectory
+)
+
+Write-Host "Creating the hashset..."
+$set = New-Object System.Collections.Generic.HashSet[string]
+Write-Host "Deciding wether to use the templates.config file or check the commit differences"
+if ($shouldGetTemplatesFromConfig) {
+    Write-Host "Reading from config file $templatesConfig"
+    [xml]$templatesXmlDoc = Get-Content -Path $script:templatesConfig
+    Write-Host "Extracting items..."
+    $templates = $templatesXmlDoc | Select-Object -ExpandProperty templates | Select-Object -ExpandProperty template
+
+    foreach ($template in $templates) {
+        Write-host "Appending $($template.name)"
+        $set.Add($template.name) >$null 2>&1  # last part is used to prevent logging the output
+    }
+} else {
+    Write-Host "Checking the commit difference"
+
+    # get changed files from last commit
+    $files=$(git diff-tree --no-commit-id --name-only -r $(Build.SourceVersion))
+    $list=$files -split ' '
+    $count=$list.Length
+    Write-Host "Total changed $count files"
+    Write-Host $list
+    Write-Host "Iterating through the list of modified files"
+    for ($i = 0; $i -lt $list.Length; $i++)
+    {
+        $endOfDirectoryName = $list[$i].IndexOf("/")
+        if ($endOfDirectoryName -gt 0) {
+            Write-Host "Getting the root path..."
+            $targetPackage = $list[$i].Substring(0, $endOfDirectoryName)
+            Write-Host "Appending $targetPackage to hashset..."
+            $set.Add($targetPackage) >$null 2>&1  # last part is used to prevent logging the output
+        }
+    }
+}
+
+Write-Host "The list of modified paths: $set"
+$absolutePath = $Env:BUILD_SOURCESDIRECTORY
+Write-Host "Absolute path is $absolutePath"
+foreach ($directory in $set) {
+    Write-Host "Current directory is $directory"
+    $directoryPath = "$absolutePath\$directory"
+    Write-Host "Directory path is $directoryPath"
+    $nuspecPath = Get-ChildItem $directoryPath -Recurse -Depth 1 -Filter *.nuspec | Select-Object -First 1 | % { $_.FullName }
+    Write-Host ".nuspec path is $nuspecPath"
+    if ($nuspecPath -And (Test-Path $nuspecPath)) {          
+        $Command = "nuget pack $nuspecPath -OutputDirectory $outputDirectory"
+        Write-Host $Command
+        Invoke-Expression $Command
+    } else {
+        Write-Host "##vso[task.LogIssue type=warning;] $nuspecPath file not found"
+    }
+}

--- a/.pipelines/azure-pipelines/azure-pipelines-Templates.yml
+++ b/.pipelines/azure-pipelines/azure-pipelines-Templates.yml
@@ -1,3 +1,9 @@
+parameters:
+  - name: shouldGetTemplatesFromConfig
+    displayName: shouldGetTemplatesFromConfig
+    type: boolean
+    default: false
+
 trigger:
   branches:
     include:

--- a/.pipelines/azure-pipelines/azure-pipelines-Templates.yml
+++ b/.pipelines/azure-pipelines/azure-pipelines-Templates.yml
@@ -1,0 +1,44 @@
+trigger:
+  branches:
+    include:
+      - develop
+      - master/*
+      - release/*
+  paths:
+    exclude:
+      - .pipelines/*
+
+pr: 
+  branches:
+    include:
+      - fix/*
+      - feature/*
+
+variables:
+  - template: ../variables/common.yml
+  - name: outputDirectory
+    value: "$(Pipeline.Workspace)/packagesDirectory"
+
+pool:
+  vmImage: 'windows-latest'
+
+jobs:
+  - job: Build
+    steps:
+    - task: NuGetToolInstaller@1
+      displayName: "Install nuget"
+
+    - task: PowerShell@2
+      inputs:
+        targetType: 'filePath'
+        filePath: $(System.DefaultWorkingDirectory)\.pipelines\azure-pipelines\DecideTemplatesToPack.ps1
+        arguments:
+          -outputDirectory '${{ variables.outputDirectory }}'
+          -shouldGetTemplatesFromConfig $(shouldGetTemplatesFromConfig)
+      displayName: "Pack modified templates"
+
+    - task: PublishBuildArtifacts@1
+      displayName: "Upload Artifacts"
+      inputs:
+        PathtoPublish: '${{ variables.outputDirectory }}'
+        ArtifactName: 'Packages'

--- a/.pipelines/azure-pipelines/azure-pipelines-Templates.yml
+++ b/.pipelines/azure-pipelines/azure-pipelines-Templates.yml
@@ -14,12 +14,6 @@ trigger:
     exclude:
       - .pipelines/*
 
-pr: 
-  branches:
-    include:
-      - fix/*
-      - feature/*
-
 variables:
   - template: ../variables/common.yml
   - name: outputDirectory

--- a/.pipelines/azure-pipelines/templates.config
+++ b/.pipelines/azure-pipelines/templates.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <template name="DocumentUnderstandingProcess" />
+</templates>


### PR DESCRIPTION
Configured a generic pipeline that packs all modified templates in the commit. The contributor doesn't need to specify the target package as the script looks for what templates have been modified and builds artifacts only for the impacted ones. If however, a build is necessary for only certain packages, then a manual build can be triggered with _shouldGetTemplatesFromConfig_ variable set true. In this scenario, all templates from _.pipelines/azure-pipelines/templates.config_ will get packed.