### PR TITLE
Studio: Updated the pipeline scripts to have the option of reading from the config file

### DIFF
--- a/.pipelines/azure-pipelines/DecideTemplatesToPack.ps1
+++ b/.pipelines/azure-pipelines/DecideTemplatesToPack.ps1
@@ -3,13 +3,16 @@ param(
 
     [string] $templatesConfig = "$PSScriptRoot\templates.config",
 
+    [string] $commitHash,
+
     [string] $outputDirectory
 )
 
 Write-Host "Creating the hashset..."
 $set = New-Object System.Collections.Generic.HashSet[string]
 Write-Host "Deciding wether to use the templates.config file or check the commit differences"
-if ($shouldGetTemplatesFromConfig) {
+Write-Host "shouldGetTemplatesFromConfig equals $shouldGetTemplatesFromConfig"
+if ($shouldGetTemplatesFromConfig -eq $true) {
     Write-Host "Reading from config file $templatesConfig"
     [xml]$templatesXmlDoc = Get-Content -Path $script:templatesConfig
     Write-Host "Extracting items..."
@@ -20,10 +23,9 @@ if ($shouldGetTemplatesFromConfig) {
         $set.Add($template.name) >$null 2>&1  # last part is used to prevent logging the output
     }
 } else {
-    Write-Host "Checking the commit difference"
-
+    Write-Host "Checking the commit difference for $commitHash"
     # get changed files from last commit
-    $files=$(git diff-tree --no-commit-id --name-only -r $(Build.SourceVersion))
+    $files=$(git diff-tree --no-commit-id --name-only -r $commitHash)
     $list=$files -split ' '
     $count=$list.Length
     Write-Host "Total changed $count files"

--- a/.pipelines/azure-pipelines/azure-pipelines-Templates.yml
+++ b/.pipelines/azure-pipelines/azure-pipelines-Templates.yml
@@ -18,6 +18,8 @@ variables:
   - template: ../variables/common.yml
   - name: outputDirectory
     value: "$(Pipeline.Workspace)/packagesDirectory"
+  - name: shouldGetTemplatesFromConfig
+    value: ${{ parameters.shouldGetTemplatesFromConfig }}
 
 pool:
   vmImage: 'windows-latest'
@@ -34,7 +36,8 @@ jobs:
         filePath: $(System.DefaultWorkingDirectory)\.pipelines\azure-pipelines\DecideTemplatesToPack.ps1
         arguments:
           -outputDirectory '${{ variables.outputDirectory }}'
-          -shouldGetTemplatesFromConfig $(shouldGetTemplatesFromConfig)
+          -commitHash $(Build.SourceVersion)
+          -shouldGetTemplatesFromConfig $$(shouldGetTemplatesFromConfig)
       displayName: "Pack modified templates"
 
     - task: PublishBuildArtifacts@1


### PR DESCRIPTION
Previously, the _shouldGetTemplatesFromConfig_ parameter would get converted to string and the option to build only the templates modified in the commit was not running even after enforcing it. This PR prevents this conversion. 