### PR TITLE
fix(CmDispatcher): advance to correct continuation

### DIFF
--- a/CommunicationsMiningDispatcher/UiPath.Template.CommunicationsMiningDispatcher.nuspec
+++ b/CommunicationsMiningDispatcher/UiPath.Template.CommunicationsMiningDispatcher.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>UiPath.Template.CommunicationsMiningDispatcher</id>
-    <version>24.7.1</version>
+    <version>24.7.2</version>
     <title>Communications Mining Dispatcher</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/CommunicationsMiningDispatcher/contentFiles/any/any/pt0/.local/template.json
+++ b/CommunicationsMiningDispatcher/contentFiles/any/any/pt0/.local/template.json
@@ -3,7 +3,7 @@
   "DefaultProjectName": "Communications Mining Dispatcher",
   "Dependencies": {
     "UiPath.CodedWorkflows": "[24.4.2]",
-    "UiPath.CommunicationsMining.Activities": "[1.1.1]",
+    "UiPath.CommunicationsMining.Activities": "[1.2.2-preview]",
     "UiPath.Cryptography.Activities": "[1.5.0]",
     "UiPath.Excel.Activities": "[2.22.3]",
     "UiPath.System.Activities": "[24.3.1]",

--- a/CommunicationsMiningDispatcher/contentFiles/any/any/pt0/VisualBasic/Framework/AdvanceStream.xaml
+++ b/CommunicationsMiningDispatcher/contentFiles/any/any/pt0/VisualBasic/Framework/AdvanceStream.xaml
@@ -2,11 +2,12 @@
   <x:Members>
     <x:Property sap2010:Annotation.AnnotationText="Dictionary structure to store configuration data of the process (settings, constants and assets)." Name="in_Config" Type="InArgument(scg:Dictionary(x:String, x:Object))" />
     <x:Property sap2010:Annotation.AnnotationText="The current batch being processed" Name="in_CurrentBatch" Type="InArgument(ucasm:GetStreamResultsResponse)" />
+    <x:Property Name="in_AdvanceToSequenceId" Type="InArgument(x:String)" />
   </x:Members>
   <VisualBasic.Settings>
     <x:Null />
   </VisualBasic.Settings>
-  <sap:VirtualizedContainerService.HintSize>1571,896</sap:VirtualizedContainerService.HintSize>
+  <sap:VirtualizedContainerService.HintSize>1656,1141</sap:VirtualizedContainerService.HintSize>
   <sap2010:WorkflowViewState.IdRef>Advance_Stream_1</sap2010:WorkflowViewState.IdRef>
   <TextExpression.NamespacesForImplementation>
     <sco:Collection x:TypeArguments="x:String">
@@ -88,17 +89,17 @@
       <AssemblyReference>UiPath.Cryptography</AssemblyReference>
     </sco:Collection>
   </TextExpression.ReferencesForImplementation>
-  <Sequence DisplayName="Advance_Stream" sap:VirtualizedContainerService.HintSize="542,831" sap2010:WorkflowViewState.IdRef="Sequence_1">
+  <Sequence DisplayName="Advance_Stream" sap:VirtualizedContainerService.HintSize="542,836" sap2010:WorkflowViewState.IdRef="Sequence_1">
     <sap:WorkflowViewStateService.ViewState>
       <scg:Dictionary x:TypeArguments="x:String, x:Object">
         <x:Boolean x:Key="IsExpanded">True</x:Boolean>
       </scg:Dictionary>
     </sap:WorkflowViewStateService.ViewState>
     <ui:LogMessage DisplayName="Log Message Advance Stream" sap:VirtualizedContainerService.HintSize="480,141" sap2010:WorkflowViewState.IdRef="LogMessage_1" Level="[UiPath.Core.Activities.LogLevel.Info]" Message="[in_Config(&quot;LogMessage_AdvanceStream&quot;).ToString()]" />
-    <ui:RetryScope DisplayName="Retry Advance Stream" sap:VirtualizedContainerService.HintSize="480,539" sap2010:WorkflowViewState.IdRef="RetryScope_1" NumberOfRetries="[CInt(in_Config(&quot;RetryNumberAdvanceStream&quot;))]">
+    <ui:RetryScope DisplayName="Retry Advance Stream" sap:VirtualizedContainerService.HintSize="480,544" sap2010:WorkflowViewState.IdRef="RetryScope_1" NumberOfRetries="[CInt(in_Config(&quot;RetryNumberAdvanceStream&quot;))]">
       <ui:RetryScope.ActivityBody>
         <ActivityAction>
-          <TryCatch DisplayName="Try and Advance Stream" sap:VirtualizedContainerService.HintSize="438,364" sap2010:WorkflowViewState.IdRef="TryCatch_1">
+          <TryCatch DisplayName="Try and Advance Stream" sap:VirtualizedContainerService.HintSize="438,369" sap2010:WorkflowViewState.IdRef="TryCatch_1">
             <sap:WorkflowViewStateService.ViewState>
               <scg:Dictionary x:TypeArguments="x:String, x:Object">
                 <x:Boolean x:Key="IsExpanded">True</x:Boolean>
@@ -106,7 +107,7 @@
               </scg:Dictionary>
             </sap:WorkflowViewStateService.ViewState>
             <TryCatch.Try>
-              <ucas:AdvanceStream Response="{x:Null}" SequenceId="{x:Null}" DisplayName="Advance Stream to ID" sap:VirtualizedContainerService.HintSize="334,136" sap2010:WorkflowViewState.IdRef="AdvanceStream_1" Stream="[in_CurrentBatch]" UseLatestSequenceId="True" />
+              <ucas:AdvanceStream Response="{x:Null}" DisplayName="Advance Stream to ID" sap:VirtualizedContainerService.HintSize="334,141" sap2010:WorkflowViewState.IdRef="AdvanceStream_1" SequenceId="[in_AdvanceToSequenceId]" Stream="[in_CurrentBatch]" UseLatestSequenceId="False" />
             </TryCatch.Try>
             <TryCatch.Catches>
               <Catch x:TypeArguments="s:Exception" sap:VirtualizedContainerService.HintSize="404,21" sap2010:WorkflowViewState.IdRef="Catch`1_1">
@@ -120,7 +121,7 @@
                   <ActivityAction.Argument>
                     <DelegateInArgument x:TypeArguments="s:Exception" Name="exception" />
                   </ActivityAction.Argument>
-                  <Sequence DisplayName="Catch Get transaction item" sap:VirtualizedContainerService.HintSize="450,231" sap2010:WorkflowViewState.IdRef="Sequence_2">
+                  <Sequence DisplayName="Catch Get transaction item" sap:VirtualizedContainerService.HintSize="450,317" sap2010:WorkflowViewState.IdRef="Sequence_2">
                     <sap:WorkflowViewStateService.ViewState>
                       <scg:Dictionary x:TypeArguments="x:String, x:Object">
                         <x:Boolean x:Key="IsExpanded">True</x:Boolean>

--- a/CommunicationsMiningDispatcher/contentFiles/any/any/pt0/VisualBasic/Framework/GetNextCommunication.xaml
+++ b/CommunicationsMiningDispatcher/contentFiles/any/any/pt0/VisualBasic/Framework/GetNextCommunication.xaml
@@ -7,7 +7,7 @@
   <VisualBasic.Settings>
     <x:Null />
   </VisualBasic.Settings>
-  <sap:VirtualizedContainerService.HintSize>1322,2216</sap:VirtualizedContainerService.HintSize>
+  <sap:VirtualizedContainerService.HintSize>1656,2217</sap:VirtualizedContainerService.HintSize>
   <sap2010:WorkflowViewState.IdRef>GetTransactionData_1</sap2010:WorkflowViewState.IdRef>
   <TextExpression.NamespacesForImplementation>
     <sco:Collection x:TypeArguments="x:String">
@@ -106,7 +106,7 @@
       <AssemblyReference>System.Linq.Async</AssemblyReference>
     </sco:Collection>
   </TextExpression.ReferencesForImplementation>
-  <Sequence sap2010:Annotation.AnnotationText="Get a transaction item from a specified source (e.g., Orchestrator queues, spreadsheets, databases, mailboxes or web APIs). &#xA;&#xA;If there are no transaction items remaining, out_TransactionItem is set to Nothing, which leads to the End Process state. &#xA;&#xA;For cases in which there is only a single transaction (i.e., a linear process), use an If activity to check whether the argument in_TransactionNumber has the value 1 (meaning it is the first and only transaction) and assign the transaction item to out_TransactionItem. For any other value of in_TransactionNumber, out_TransactionItem should be set to Nothing.&#xA;&#xA;If there are multiple transactions, use the argument in_TransactionNumber as an index to retrieve the correct transaction to be processed. If there are no more transactions left, it is necessary to set out_TransactionItem to Nothing, thus ending the process." DisplayName="Get Transaction Data" sap:VirtualizedContainerService.HintSize="648,2151" sap2010:WorkflowViewState.IdRef="Sequence_1">
+  <Sequence sap2010:Annotation.AnnotationText="Get a transaction item from a specified source (e.g., Orchestrator queues, spreadsheets, databases, mailboxes or web APIs). &#xA;&#xA;If there are no transaction items remaining, out_TransactionItem is set to Nothing, which leads to the End Process state. &#xA;&#xA;For cases in which there is only a single transaction (i.e., a linear process), use an If activity to check whether the argument in_TransactionNumber has the value 1 (meaning it is the first and only transaction) and assign the transaction item to out_TransactionItem. For any other value of in_TransactionNumber, out_TransactionItem should be set to Nothing.&#xA;&#xA;If there are multiple transactions, use the argument in_TransactionNumber as an index to retrieve the correct transaction to be processed. If there are no more transactions left, it is necessary to set out_TransactionItem to Nothing, thus ending the process." DisplayName="Get Transaction Data" sap:VirtualizedContainerService.HintSize="648,2152" sap2010:WorkflowViewState.IdRef="Sequence_1">
     <sap:WorkflowViewStateService.ViewState>
       <scg:Dictionary x:TypeArguments="x:String, x:Object">
         <x:Boolean x:Key="IsExpanded">True</x:Boolean>
@@ -114,9 +114,9 @@
       </scg:Dictionary>
     </sap:WorkflowViewStateService.ViewState>
     <ui:LogMessage DisplayName="Log Message Get Transaction Item" sap:VirtualizedContainerService.HintSize="586,141" sap2010:WorkflowViewState.IdRef="LogMessage_1" Level="Info" Message="[in_Config(&quot;LogMessage_GettingCommunication&quot;).ToString()]" />
-    <ui:InterruptibleDoWhile CurrentIndex="{x:Null}" Condition="[out_CurrentResult Is nothing and io_CurrentBatch.MoreResults]" DisplayName="Do While Results Exist in the Stream" sap:VirtualizedContainerService.HintSize="586,1637" sap2010:WorkflowViewState.IdRef="InterruptibleDoWhile_1">
+    <ui:InterruptibleDoWhile CurrentIndex="{x:Null}" Condition="[out_CurrentResult Is nothing and io_CurrentBatch.MoreResults]" DisplayName="Do While Results Exist in the Stream" sap:VirtualizedContainerService.HintSize="586,1638" sap2010:WorkflowViewState.IdRef="InterruptibleDoWhile_1">
       <ui:InterruptibleDoWhile.Body>
-        <Sequence DisplayName="Body" sap:VirtualizedContainerService.HintSize="552,1501" sap2010:WorkflowViewState.IdRef="Sequence_16">
+        <Sequence DisplayName="Body" sap:VirtualizedContainerService.HintSize="552,1502" sap2010:WorkflowViewState.IdRef="Sequence_16">
           <sap:WorkflowViewStateService.ViewState>
             <scg:Dictionary x:TypeArguments="x:String, x:Object">
               <x:Boolean x:Key="IsExpanded">True</x:Boolean>
@@ -154,7 +154,7 @@
               </Sequence>
             </If.Else>
           </If>
-          <If Condition="[io_CurrentBatch.Results.Any()]" DisplayName="Get Next Item" sap:VirtualizedContainerService.HintSize="510,990" sap2010:WorkflowViewState.IdRef="If_2">
+          <If Condition="[io_CurrentBatch.Results.Any()]" DisplayName="Get Next Item" sap:VirtualizedContainerService.HintSize="510,991" sap2010:WorkflowViewState.IdRef="If_2">
             <sap:WorkflowViewStateService.ViewState>
               <scg:Dictionary x:TypeArguments="x:String, x:Object">
                 <x:Boolean x:Key="IsExpanded">True</x:Boolean>
@@ -162,13 +162,13 @@
               </scg:Dictionary>
             </sap:WorkflowViewStateService.ViewState>
             <If.Then>
-              <Sequence sap:VirtualizedContainerService.HintSize="476,426" sap2010:WorkflowViewState.IdRef="Sequence_8">
+              <Sequence sap:VirtualizedContainerService.HintSize="476,427" sap2010:WorkflowViewState.IdRef="Sequence_8">
                 <sap:WorkflowViewStateService.ViewState>
                   <scg:Dictionary x:TypeArguments="x:String, x:Object">
                     <x:Boolean x:Key="IsExpanded">True</x:Boolean>
                   </scg:Dictionary>
                 </sap:WorkflowViewStateService.ViewState>
-                <Assign DisplayName="Get Next Result" sap:VirtualizedContainerService.HintSize="434,81" sap2010:WorkflowViewState.IdRef="Assign_8">
+                <Assign DisplayName="Get Next Result" sap:VirtualizedContainerService.HintSize="434,82" sap2010:WorkflowViewState.IdRef="Assign_8">
                   <Assign.To>
                     <OutArgument x:TypeArguments="ucasm:StreamResult">[out_CurrentResult]</OutArgument>
                   </Assign.To>
@@ -194,6 +194,9 @@
                     </InArgument>
                     <InArgument x:TypeArguments="ucasm:GetStreamResultsResponse" x:Key="in_CurrentBatch">
                       <VisualBasicValue x:TypeArguments="ucasm:GetStreamResultsResponse" ExpressionText="io_CurrentBatch" />
+                    </InArgument>
+                    <InArgument x:TypeArguments="x:String" x:Key="in_AdvanceToSequenceId">
+                      <VisualBasicValue x:TypeArguments="x:String" ExpressionText="io_CurrentBatch.SequenceId" />
                     </InArgument>
                   </ui:InvokeWorkflowFile.Arguments>
                 </ui:InvokeWorkflowFile>

--- a/CommunicationsMiningDispatcher/contentFiles/any/any/pt0/VisualBasic/Main.xaml
+++ b/CommunicationsMiningDispatcher/contentFiles/any/any/pt0/VisualBasic/Main.xaml
@@ -8,7 +8,7 @@
   <VisualBasic.Settings>
     <x:Null />
   </VisualBasic.Settings>
-  <sap:VirtualizedContainerService.HintSize>761,887</sap:VirtualizedContainerService.HintSize>
+  <sap:VirtualizedContainerService.HintSize>1194,864</sap:VirtualizedContainerService.HintSize>
   <sap2010:WorkflowViewState.IdRef>Main2_1</sap2010:WorkflowViewState.IdRef>
   <TextExpression.NamespacesForImplementation>
     <sco:Collection x:TypeArguments="x:String">
@@ -110,9 +110,10 @@
       <AssemblyReference>UiPath.Excel.Activities.Design</AssemblyReference>
       <AssemblyReference>CommunicationsMiningDispatcher.Core</AssemblyReference>
       <AssemblyReference>System.Linq.Async</AssemblyReference>
+      <AssemblyReference>Communications Mining Dispatcher.Core</AssemblyReference>
     </scg:List>
   </TextExpression.ReferencesForImplementation>
-  <StateMachine InitialState="{x:Reference __ReferenceID3}" sap2010:Annotation.AnnotationText="[Process title]&#xA;[Process description]&#xA;[Additional information (e.g., author, contact information and applications involved and required external setup)]" DisplayName="CommunicationsMiningFramework 24.7.1" sap:VirtualizedContainerService.HintSize="771,799" sap2010:WorkflowViewState.IdRef="StateMachine_1">
+  <StateMachine InitialState="{x:Reference __ReferenceID3}" sap2010:Annotation.AnnotationText="[Process title]&#xA;[Process description]&#xA;[Additional information (e.g., author, contact information and applications involved and required external setup)]" DisplayName="CommunicationsMiningFramework 24.7.2" sap:VirtualizedContainerService.HintSize="771,799" sap2010:WorkflowViewState.IdRef="StateMachine_1">
     <sap:WorkflowViewStateService.ViewState>
       <scg:Dictionary x:TypeArguments="x:String, x:Object">
         <x:Boolean x:Key="IsExpanded">True</x:Boolean>
@@ -125,7 +126,7 @@
     </sap:WorkflowViewStateService.ViewState>
     <State x:Name="__ReferenceID0" sap2010:Annotation.AnnotationText="Get the next communication to be processed." DisplayName="Get Communication" sap:VirtualizedContainerService.HintSize="251,113" sap2010:WorkflowViewState.IdRef="State_4">
       <State.Entry>
-        <Sequence sap2010:Annotation.AnnotationText="Retrieve a new transaction data to be processed.&#xA;The TransactionNumber variable holds the current transaction number and incrementing this variable makes the framework retrieve the next transaction. If the framework is retrying a failed transaction, this variable is not incremented until the maximum number of retry attempts is reached." DisplayName="Retrieve Data" sap:VirtualizedContainerService.HintSize="674,1540" sap2010:WorkflowViewState.IdRef="Sequence_25">
+        <Sequence sap2010:Annotation.AnnotationText="Retrieve a new transaction data to be processed.&#xA;The TransactionNumber variable holds the current transaction number and incrementing this variable makes the framework retrieve the next transaction. If the framework is retrying a failed transaction, this variable is not incremented until the maximum number of retry attempts is reached." DisplayName="Retrieve Data" sap:VirtualizedContainerService.HintSize="576,1275" sap2010:WorkflowViewState.IdRef="Sequence_25">
           <Sequence.Variables>
             <Variable x:TypeArguments="x:Boolean" Name="StopRequestedFromOrchestrator" />
           </Sequence.Variables>
@@ -136,7 +137,7 @@
               <x:Boolean x:Key="IsPinned">False</x:Boolean>
             </scg:Dictionary>
           </sap:WorkflowViewStateService.ViewState>
-          <Assign DisplayName="Current Result is Nothing" sap:VirtualizedContainerService.HintSize="612,82" sap2010:WorkflowViewState.IdRef="Assign_31">
+          <Assign DisplayName="Current Result is Nothing" sap:VirtualizedContainerService.HintSize="514,82" sap2010:WorkflowViewState.IdRef="Assign_31">
             <Assign.To>
               <OutArgument x:TypeArguments="ucasm:StreamResult">[CurrentResult]</OutArgument>
             </Assign.To>
@@ -144,7 +145,7 @@
               <InArgument x:TypeArguments="ucasm:StreamResult">[Nothing]</InArgument>
             </Assign.Value>
           </Assign>
-          <ui:ShouldStop DisplayName="Check Stop Signal" sap:VirtualizedContainerService.HintSize="612,90" sap2010:WorkflowViewState.IdRef="ShouldStop_2" Result="[StopRequestedFromOrchestrator]">
+          <ui:ShouldStop DisplayName="Check Stop Signal" sap:VirtualizedContainerService.HintSize="514,90" sap2010:WorkflowViewState.IdRef="ShouldStop_2" Result="[StopRequestedFromOrchestrator]">
             <sap:WorkflowViewStateService.ViewState>
               <scg:Dictionary x:TypeArguments="x:String, x:Object">
                 <x:Boolean x:Key="IsExpanded">True</x:Boolean>
@@ -152,7 +153,7 @@
               </scg:Dictionary>
             </sap:WorkflowViewStateService.ViewState>
           </ui:ShouldStop>
-          <If Condition="[StopRequestedFromOrchestrator]" DisplayName="If Stop Requested from Orchestrator" sap:VirtualizedContainerService.HintSize="612,1105" sap2010:WorkflowViewState.IdRef="If_16">
+          <If Condition="[StopRequestedFromOrchestrator]" DisplayName="If Stop Requested from Orchestrator" sap:VirtualizedContainerService.HintSize="514,840" sap2010:WorkflowViewState.IdRef="If_16">
             <If.Then>
               <Sequence sap:VirtualizedContainerService.HintSize="376,229" sap2010:WorkflowViewState.IdRef="Sequence_34">
                 <sap:WorkflowViewStateService.ViewState>
@@ -164,13 +165,13 @@
               </Sequence>
             </If.Then>
             <If.Else>
-              <Sequence sap:VirtualizedContainerService.HintSize="578,694" sap2010:WorkflowViewState.IdRef="Sequence_35">
+              <Sequence sap:VirtualizedContainerService.HintSize="480,429" sap2010:WorkflowViewState.IdRef="Sequence_35">
                 <sap:WorkflowViewStateService.ViewState>
                   <scg:Dictionary x:TypeArguments="x:String, x:Object">
                     <x:Boolean x:Key="IsExpanded">True</x:Boolean>
                   </scg:Dictionary>
                 </sap:WorkflowViewStateService.ViewState>
-                <TryCatch DisplayName="Try GetTransactionData" sap:VirtualizedContainerService.HintSize="536,606" sap2010:WorkflowViewState.IdRef="TryCatch_7">
+                <TryCatch DisplayName="Try GetTransactionData" sap:VirtualizedContainerService.HintSize="438,341" sap2010:WorkflowViewState.IdRef="TryCatch_7">
                   <sap:WorkflowViewStateService.ViewState>
                     <scg:Dictionary x:TypeArguments="x:String, x:Object">
                       <x:Boolean x:Key="IsExpanded">True</x:Boolean>
@@ -187,10 +188,10 @@
                     </ui:InvokeWorkflowFile>
                   </TryCatch.Try>
                   <TryCatch.Catches>
-                    <Catch x:TypeArguments="s:Exception" sap:VirtualizedContainerService.HintSize="502,443" sap2010:WorkflowViewState.IdRef="Catch`1_8">
+                    <Catch x:TypeArguments="s:Exception" sap:VirtualizedContainerService.HintSize="404,21" sap2010:WorkflowViewState.IdRef="Catch`1_8">
                       <sap:WorkflowViewStateService.ViewState>
                         <scg:Dictionary x:TypeArguments="x:String, x:Object">
-                          <x:Boolean x:Key="IsExpanded">True</x:Boolean>
+                          <x:Boolean x:Key="IsExpanded">False</x:Boolean>
                           <x:Boolean x:Key="IsPinned">False</x:Boolean>
                         </scg:Dictionary>
                       </sap:WorkflowViewStateService.ViewState>
@@ -198,7 +199,7 @@
                         <ActivityAction.Argument>
                           <DelegateInArgument x:TypeArguments="s:Exception" Name="Exception" />
                         </ActivityAction.Argument>
-                        <Sequence DisplayName="Log exception message and end process" sap:VirtualizedContainerService.HintSize="496,374" sap2010:WorkflowViewState.IdRef="Sequence_24">
+                        <Sequence DisplayName="Log exception message and end process" sap:VirtualizedContainerService.HintSize="496,288" sap2010:WorkflowViewState.IdRef="Sequence_24">
                           <sap:WorkflowViewStateService.ViewState>
                             <scg:Dictionary x:TypeArguments="x:String, x:Object">
                               <x:Boolean x:Key="IsExpanded">True</x:Boolean>
@@ -245,7 +246,7 @@
             </scg:Dictionary>
           </sap:WorkflowViewStateService.ViewState>
           <Transition.To>
-            <State x:Name="__ReferenceID2" sap2010:Annotation.AnnotationText="Process a single Communication. &#xA;The result of the processing can be: 1) Success, 2) System Exception. " DisplayName="Process Communication" sap:VirtualizedContainerService.HintSize="231,128" sap2010:WorkflowViewState.IdRef="State_3">
+            <State x:Name="__ReferenceID2" sap2010:Annotation.AnnotationText="Process a single Communication. &#xA;The result of the processing can be: 1) Success, 2) System Exception. " DisplayName="Process Communication" sap:VirtualizedContainerService.HintSize="556,1709" sap2010:WorkflowViewState.IdRef="State_3">
               <State.Entry>
                 <TryCatch DisplayName="Try to process transaction" sap:VirtualizedContainerService.HintSize="510,1279" sap2010:WorkflowViewState.IdRef="TryCatch_9">
                   <sap:WorkflowViewStateService.ViewState>
@@ -291,8 +292,15 @@
                             </ui:InvokeWorkflowFile>
                             <ui:InvokeWorkflowFile ArgumentsVariable="{x:Null}" ContinueOnError="{x:Null}" DisplayName="Framework\Advance Stream.xaml - Invoke Workflow File" sap:VirtualizedContainerService.HintSize="334,113" sap2010:WorkflowViewState.IdRef="InvokeWorkflowFile_27" UnSafe="False" WorkflowFileName="Framework\AdvanceStream.xaml">
                               <ui:InvokeWorkflowFile.Arguments>
-                                <InArgument x:TypeArguments="scg:Dictionary(x:String, x:Object)" x:Key="in_Config">[in_Config]</InArgument>
-                                <InArgument x:TypeArguments="ucasm:GetStreamResultsResponse" x:Key="in_CurrentBatch">[CurrentBatch]</InArgument>
+                                <InArgument x:TypeArguments="scg:Dictionary(x:String, x:Object)" x:Key="in_Config">
+                                  <VisualBasicValue x:TypeArguments="scg:Dictionary(x:String, x:Object)" ExpressionText="in_Config" />
+                                </InArgument>
+                                <InArgument x:TypeArguments="ucasm:GetStreamResultsResponse" x:Key="in_CurrentBatch">
+                                  <VisualBasicValue x:TypeArguments="ucasm:GetStreamResultsResponse" ExpressionText="CurrentBatch" />
+                                </InArgument>
+                                <InArgument x:TypeArguments="x:String" x:Key="in_AdvanceToSequenceId">
+                                  <VisualBasicValue x:TypeArguments="x:String" ExpressionText="CurrentResult.Continuation" />
+                                </InArgument>
                               </ui:InvokeWorkflowFile.Arguments>
                             </ui:InvokeWorkflowFile>
                           </Sequence>

--- a/CommunicationsMiningDispatcher/contentFiles/any/any/pt0/VisualBasic/project.json
+++ b/CommunicationsMiningDispatcher/contentFiles/any/any/pt0/VisualBasic/project.json
@@ -5,7 +5,7 @@
   "main": "Main.xaml",
   "dependencies": {
     "UiPath.CodedWorkflows": "[24.4.2]",
-    "UiPath.CommunicationsMining.Activities": "[1.1.1]",
+    "UiPath.CommunicationsMining.Activities": "[1.2.2-preview]",
     "UiPath.Cryptography.Activities": "[1.5.0]",
     "UiPath.Excel.Activities": "[2.22.3]",
     "UiPath.System.Activities": "[24.3.1]",


### PR DESCRIPTION
Fixes an issue where the template would advance to the batches sequence id on main loop, not the sequence id of the current comment 