### PR TITLE
Add System.Drawing.Common and System.Drawing.Primities AssemblyReference to all bundled templates

### DIFF
--- a/AddChartToPowerPointPresentationFromExcel/UiPath.Template.AddChartToPowerPointPresentationFromExcel.nuspec
+++ b/AddChartToPowerPointPresentationFromExcel/UiPath.Template.AddChartToPowerPointPresentationFromExcel.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>UiPath.Template.AddChartToPowerPointPresentationFromExcel</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>AddChartToPowerPointPresentationFromExcelTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/AddChartToPowerPointPresentationFromExcel/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
+++ b/AddChartToPowerPointPresentationFromExcel/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
@@ -62,7 +62,9 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
 	  <AssemblyReference>System.Data.Common</AssemblyReference>
-      <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing</AssemblyReference> 
+      <AssemblyReference>System.Drawing.Common</AssemblyReference> 
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AddChartToPowerPointPresentationFromExcel/contentFiles/any/any/pt0/VisualBasic/Main.xaml
+++ b/AddChartToPowerPointPresentationFromExcel/contentFiles/any/any/pt0/VisualBasic/Main.xaml
@@ -44,7 +44,9 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
-      <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing</AssemblyReference> 
+      <AssemblyReference>System.Drawing.Common</AssemblyReference> 
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/UiPath.Template.AttendedAutomationFramework.nuspec
+++ b/AttendedAutomationFramework/UiPath.Template.AttendedAutomationFramework.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>UiPath.Template.AttendedAutomationFramework</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>NewAttendedAutomationFrameworkTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/ConfigUtility.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/ConfigUtility.xaml
@@ -43,6 +43,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_ConfigUtility/onClick_Cancel.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_ConfigUtility/onClick_Cancel.xaml
@@ -51,6 +51,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_ConfigUtility/onClick_ResetAllValues.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_ConfigUtility/onClick_ResetAllValues.xaml
@@ -53,6 +53,8 @@
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_ConfigUtility/onClick_SaveConfigUtility.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_ConfigUtility/onClick_SaveConfigUtility.xaml
@@ -62,6 +62,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Error/onClick_Close.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Error/onClick_Close.xaml
@@ -51,6 +51,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Error/onClick_EmailError.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Error/onClick_EmailError.xaml
@@ -49,6 +49,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Error/onClick_RepeatProcess.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Error/onClick_RepeatProcess.xaml
@@ -52,6 +52,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Inputs/Process.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Inputs/Process.xaml
@@ -47,6 +47,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Inputs/onClick_Cancel.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Inputs/onClick_Cancel.xaml
@@ -51,6 +51,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Inputs/onClick_Continue.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Inputs/onClick_Continue.xaml
@@ -59,6 +59,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Inputs/onClick_SelectFolder.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Inputs/onClick_SelectFolder.xaml
@@ -51,6 +51,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Inputs/onClick_ViewUserGuide.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Inputs/onClick_ViewUserGuide.xaml
@@ -52,6 +52,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Success/onClick_Close.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Success/onClick_Close.xaml
@@ -52,6 +52,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Success/onClick_RepeatProcess.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Success/onClick_RepeatProcess.xaml
@@ -54,6 +54,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Success/onClick_ViewOutput.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Form_Success/onClick_ViewOutput.xaml
@@ -49,6 +49,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Framework_Workflows/CheckAndGetConfig.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Framework_Workflows/CheckAndGetConfig.xaml
@@ -35,6 +35,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Framework_Workflows/InitAllSettings.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Framework_Workflows/InitAllSettings.xaml
@@ -50,6 +50,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Framework_Workflows/RunLocalTriggers.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Framework_Workflows/RunLocalTriggers.xaml
@@ -38,6 +38,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Framework_Workflows/TakeScreenshot.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Framework_Workflows/TakeScreenshot.xaml
@@ -45,6 +45,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Main.xaml
+++ b/AttendedAutomationFramework/contentFiles/any/any/pt0/VisualBasic/Main.xaml
@@ -58,6 +58,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>
@@ -87,8 +89,6 @@
       <AssemblyReference>System.Private.Uri</AssemblyReference>
       <AssemblyReference>UiPath.Workflow</AssemblyReference>
       <AssemblyReference>Newtonsoft.Json</AssemblyReference>
-      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
-      <AssemblyReference>System.Drawing.Common</AssemblyReference>
       <AssemblyReference>System.Windows.Forms.Primitives</AssemblyReference>
       <AssemblyReference>System.Windows.Forms</AssemblyReference>
       <AssemblyReference>System.Text.RegularExpressions</AssemblyReference>

--- a/BackgroundProcess/UiPath.Template.BackgroundProcess.nuspec
+++ b/BackgroundProcess/UiPath.Template.BackgroundProcess.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>UiPath.Template.BackgroundProcess</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>NewBackgroundProcessTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/BackgroundProcess/contentFiles/any/any/pt2/VisualBasic/Main.xaml
+++ b/BackgroundProcess/contentFiles/any/any/pt2/VisualBasic/Main.xaml
@@ -35,6 +35,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/BackgroundProcess/contentFiles/any/any/pt3/CSharp/Main.xaml
+++ b/BackgroundProcess/contentFiles/any/any/pt3/CSharp/Main.xaml
@@ -51,6 +51,8 @@ sap2010:ExpressionActivityEditor.ExpressionActivityEditor="C#">
             <AssemblyReference>Microsoft.VisualBasic</AssemblyReference>
             <AssemblyReference>System.Private.CoreLib</AssemblyReference>
             <AssemblyReference>System.Drawing</AssemblyReference>
+            <AssemblyReference>System.Drawing.Common</AssemblyReference>
+            <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
             <AssemblyReference>System.Xml</AssemblyReference>
             <AssemblyReference>System.Xml.Linq</AssemblyReference>
             <AssemblyReference>PresentationFramework</AssemblyReference>

--- a/CompleteWordTemplatefromExcelandEmail/UiPath.Template.CompleteWordTemplatefromExcelandEmail.nuspec
+++ b/CompleteWordTemplatefromExcelandEmail/UiPath.Template.CompleteWordTemplatefromExcelandEmail.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>UiPath.Template.CompleteWordTemplatefromExcelandEmail</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>CompleteWordTemplatefromExcelandEmailTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/CompleteWordTemplatefromExcelandEmail/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
+++ b/CompleteWordTemplatefromExcelandEmail/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
@@ -63,6 +63,8 @@
       <AssemblyReference>System</AssemblyReference>
 	  <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/CompleteWordTemplatefromExcelandEmail/contentFiles/any/any/pt0/VisualBasic/Main.xaml
+++ b/CompleteWordTemplatefromExcelandEmail/contentFiles/any/any/pt0/VisualBasic/Main.xaml
@@ -50,6 +50,8 @@
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/CreatePowerPointPresentation/UiPath.Template.CreatePowerPointPresentation.nuspec
+++ b/CreatePowerPointPresentation/UiPath.Template.CreatePowerPointPresentation.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>UiPath.Template.CreatePowerPointPresentation</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>CreatePowerPointPresentationFromDataScrapingTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/CreatePowerPointPresentation/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
+++ b/CreatePowerPointPresentation/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
@@ -68,6 +68,8 @@
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>
       <AssemblyReference>System.Private.CoreLib</AssemblyReference>

--- a/CreatePowerPointPresentation/contentFiles/any/any/pt0/VisualBasic/Main.xaml
+++ b/CreatePowerPointPresentation/contentFiles/any/any/pt0/VisualBasic/Main.xaml
@@ -69,6 +69,8 @@
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Data.SqlClient</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>
       <AssemblyReference>System.Memory.Data</AssemblyReference>

--- a/CreateRichHtmlEmail/UiPath.Template.CreateRichHtmlEmail.nuspec
+++ b/CreateRichHtmlEmail/UiPath.Template.CreateRichHtmlEmail.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>UiPath.Template.CreateRichHtmlEmail</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>CreateRichHtmlEmailTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/CreateRichHtmlEmail/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
+++ b/CreateRichHtmlEmail/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
@@ -63,6 +63,8 @@
       <AssemblyReference>System</AssemblyReference>
 	  <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/CreateRichHtmlEmail/contentFiles/any/any/pt0/VisualBasic/Main.xaml
+++ b/CreateRichHtmlEmail/contentFiles/any/any/pt0/VisualBasic/Main.xaml
@@ -52,6 +52,8 @@
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/CrossBrowserTesting/UiPath.Template.CrossBrowserTesting.nuspec
+++ b/CrossBrowserTesting/UiPath.Template.CrossBrowserTesting.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>UiPath.Template.CrossBrowserTesting</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>CrossBrowserTestingTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/CrossBrowserTesting/contentFiles/any/any/pt2/VisualBasic/.templates/CrossBrowserTesting_CustomBrowsers_TestCaseTemplate.xaml
+++ b/CrossBrowserTesting/contentFiles/any/any/pt2/VisualBasic/.templates/CrossBrowserTesting_CustomBrowsers_TestCaseTemplate.xaml
@@ -58,6 +58,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Drawing.Common</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>

--- a/CrossBrowserTesting/contentFiles/any/any/pt2/VisualBasic/.templates/CrossBrowserTesting_ExecutionTemplate.xaml
+++ b/CrossBrowserTesting/contentFiles/any/any/pt2/VisualBasic/.templates/CrossBrowserTesting_ExecutionTemplate.xaml
@@ -50,6 +50,8 @@
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Drawing.Common</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>

--- a/CrossBrowserTesting/contentFiles/any/any/pt2/VisualBasic/.templates/CrossBrowserTesting_TestCaseTemplate.xaml
+++ b/CrossBrowserTesting/contentFiles/any/any/pt2/VisualBasic/.templates/CrossBrowserTesting_TestCaseTemplate.xaml
@@ -58,6 +58,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Drawing.Common</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>

--- a/CrossBrowserTesting/contentFiles/any/any/pt3/CSharp/.templates/CrossBrowserTesting_CustomBrowsers_TestCaseTemplate.xaml
+++ b/CrossBrowserTesting/contentFiles/any/any/pt3/CSharp/.templates/CrossBrowserTesting_CustomBrowsers_TestCaseTemplate.xaml
@@ -75,6 +75,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/CrossBrowserTesting/contentFiles/any/any/pt3/CSharp/.templates/CrossBrowserTesting_TestCaseTemplate.xaml
+++ b/CrossBrowserTesting/contentFiles/any/any/pt3/CSharp/.templates/CrossBrowserTesting_TestCaseTemplate.xaml
@@ -75,6 +75,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/DownloadFile/UiPath.Template.DownloadFile.nuspec
+++ b/DownloadFile/UiPath.Template.DownloadFile.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>UiPath.Template.DownloadFile</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>DownloadFileTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/DownloadFile/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
+++ b/DownloadFile/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
@@ -68,6 +68,8 @@
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>
       <AssemblyReference>System.Private.CoreLib</AssemblyReference>

--- a/DownloadFile/contentFiles/any/any/pt0/VisualBasic/Main.xaml
+++ b/DownloadFile/contentFiles/any/any/pt0/VisualBasic/Main.xaml
@@ -61,6 +61,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>
       <AssemblyReference>System.Memory.Data</AssemblyReference>

--- a/EnterExcelDataIntoWebsite/UiPath.Template.EnterExcelDataIntoWebsite.nuspec
+++ b/EnterExcelDataIntoWebsite/UiPath.Template.EnterExcelDataIntoWebsite.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>UiPath.Template.EnterExcelDataIntoWesbsite</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>EnterExcelRangeIntoWebsiteTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/EnterExcelDataIntoWebsite/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
+++ b/EnterExcelDataIntoWebsite/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
@@ -62,6 +62,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/EnterExcelDataIntoWebsite/contentFiles/any/any/pt0/VisualBasic/Main.xaml
+++ b/EnterExcelDataIntoWebsite/contentFiles/any/any/pt0/VisualBasic/Main.xaml
@@ -52,6 +52,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/MobileTestingProject/UiPath.Template.MobileTestingProject.nuspec
+++ b/MobileTestingProject/UiPath.Template.MobileTestingProject.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>UiPath.Template.MobileTestingProject</id>
-    <version>24.10.0</version>
+    <version>24.10.1</version>
     <title>NewMobileTestingProjectTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/MobileTestingProject/contentFiles/any/any/pt2/VisualBasic/TestCase.xaml
+++ b/MobileTestingProject/contentFiles/any/any/pt2/VisualBasic/TestCase.xaml
@@ -33,6 +33,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/MobileTestingProject/contentFiles/any/any/pt3/CSharp/TestCase.xaml
+++ b/MobileTestingProject/contentFiles/any/any/pt3/CSharp/TestCase.xaml
@@ -41,6 +41,8 @@
       <AssemblyReference>Microsoft.VisualBasic</AssemblyReference>
       <AssemblyReference>System.Private.CoreLib</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>
       <AssemblyReference>PresentationFramework</AssemblyReference>

--- a/OrchestrationProcess/UiPath.Template.OrchestrationProcess.nuspec
+++ b/OrchestrationProcess/UiPath.Template.OrchestrationProcess.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>UiPath.Template.OrchestrationProcess</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>NewOrchestrationProcessTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/BusinessProcess/StartBusinessProcessing.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/BusinessProcess/StartBusinessProcessing.xaml
@@ -51,6 +51,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Private.CoreLib</AssemblyReference>
       <AssemblyReference>System.Xaml</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Framework/AfterResume.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Framework/AfterResume.xaml
@@ -47,6 +47,8 @@
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Private.CoreLib</AssemblyReference>
       <AssemblyReference>System.Xaml</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Framework/BusinessProcess.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Framework/BusinessProcess.xaml
@@ -51,6 +51,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>
       <AssemblyReference>System.Private.CoreLib</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Framework/EvaluateTaskAssignmentRule.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Framework/EvaluateTaskAssignmentRule.xaml
@@ -52,6 +52,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Private.CoreLib</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Framework/GetTaskBatches.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Framework/GetTaskBatches.xaml
@@ -53,6 +53,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Framework/InitConfig.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Framework/InitConfig.xaml
@@ -54,6 +54,8 @@
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Private.CoreLib</AssemblyReference>
       <AssemblyReference>System.Private.Xml</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Framework/TasksAssignment.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Framework/TasksAssignment.xaml
@@ -52,6 +52,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Main.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt2/VisualBasic/Main.xaml
@@ -61,6 +61,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/BusinessProcess/StartBusinessProcessing.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/BusinessProcess/StartBusinessProcessing.xaml
@@ -50,6 +50,8 @@
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/AfterResume.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/AfterResume.xaml
@@ -44,6 +44,8 @@
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Private.CoreLib</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/BusinessProcess.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/BusinessProcess.xaml
@@ -51,6 +51,8 @@
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/EvaluateTaskAssignmentRule.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/EvaluateTaskAssignmentRule.xaml
@@ -47,6 +47,8 @@
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/GetTaskBatches.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/GetTaskBatches.xaml
@@ -53,6 +53,8 @@
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>
       <AssemblyReference>System.Private.CoreLib</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/InitAssignmentConfig.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/InitAssignmentConfig.xaml
@@ -52,6 +52,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Private.CoreLib</AssemblyReference>
       <AssemblyReference>System.Private.Xml</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/InitConfig.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/InitConfig.xaml
@@ -62,6 +62,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>
       <AssemblyReference>System.Private.CoreLib</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/TasksAssignment.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Framework/TasksAssignment.xaml
@@ -53,6 +53,8 @@
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>

--- a/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Main.xaml
+++ b/OrchestrationProcess/contentFiles/any/any/pt3/CSharp/Main.xaml
@@ -63,6 +63,8 @@
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>

--- a/SaveDesktopOutlookEmailAttachmentsToSharepointOrOneDrive/UiPath.Template.SaveDesktopOutlookEmailAttachmentsToSharepointOrOneDrive.nuspec
+++ b/SaveDesktopOutlookEmailAttachmentsToSharepointOrOneDrive/UiPath.Template.SaveDesktopOutlookEmailAttachmentsToSharepointOrOneDrive.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>UiPath.Template.SaveDesktopOutlookEmailAttachmentsToSharepointOrOneDrive</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>SaveDesktopOutlookEmailAttachmentsToSharepointOrOneDriveTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/SaveDesktopOutlookEmailAttachmentsToSharepointOrOneDrive/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
+++ b/SaveDesktopOutlookEmailAttachmentsToSharepointOrOneDrive/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
@@ -62,6 +62,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/SaveDesktopOutlookEmailAttachmentsToSharepointOrOneDrive/contentFiles/any/any/pt0/VisualBasic/Main.xaml
+++ b/SaveDesktopOutlookEmailAttachmentsToSharepointOrOneDrive/contentFiles/any/any/pt0/VisualBasic/Main.xaml
@@ -55,6 +55,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/SaveGMailAttachmentsToGoogleDrive/UiPath.Template.SaveGMailAttachmentsToGoogleDrive.nuspec
+++ b/SaveGMailAttachmentsToGoogleDrive/UiPath.Template.SaveGMailAttachmentsToGoogleDrive.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>UiPath.Template.SaveGMailAttachmentsToGoogleDrive</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>SaveGMailAttachmentsToGoogleDriveTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/SaveGMailAttachmentsToGoogleDrive/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
+++ b/SaveGMailAttachmentsToGoogleDrive/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
@@ -62,6 +62,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/SaveGMailAttachmentsToGoogleDrive/contentFiles/any/any/pt0/VisualBasic/Main.xaml
+++ b/SaveGMailAttachmentsToGoogleDrive/contentFiles/any/any/pt0/VisualBasic/Main.xaml
@@ -51,6 +51,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/SaveOutlook365AttachmentsToSharepointorOneDrive/UiPath.Template.SaveOutlook365AttachmentsToSharepointorOneDrive.nuspec
+++ b/SaveOutlook365AttachmentsToSharepointorOneDrive/UiPath.Template.SaveOutlook365AttachmentsToSharepointorOneDrive.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>UiPath.Template.SaveOutlook365AttachmentsToSharepointorOneDrive</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>SaveOutlook365AttachmentsToSharepointorOneDriveTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/SaveOutlook365AttachmentsToSharepointorOneDrive/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
+++ b/SaveOutlook365AttachmentsToSharepointorOneDrive/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
@@ -62,6 +62,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/SaveOutlook365AttachmentsToSharepointorOneDrive/contentFiles/any/any/pt0/VisualBasic/Main.xaml
+++ b/SaveOutlook365AttachmentsToSharepointorOneDrive/contentFiles/any/any/pt0/VisualBasic/Main.xaml
@@ -55,6 +55,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/SaveOutlookAttachments/UiPath.Template.SaveOutlookAttachments.nuspec
+++ b/SaveOutlookAttachments/UiPath.Template.SaveOutlookAttachments.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>UiPath.Template.SaveOutlookAttachments</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>SaveOutlookAttachmentsTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/SaveOutlookAttachments/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
+++ b/SaveOutlookAttachments/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
@@ -62,6 +62,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/SaveOutlookAttachments/contentFiles/any/any/pt0/VisualBasic/Main.xaml
+++ b/SaveOutlookAttachments/contentFiles/any/any/pt0/VisualBasic/Main.xaml
@@ -44,6 +44,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/SplitExcelSheet/UiPath.Template.SplitExcelSheet.nuspec
+++ b/SplitExcelSheet/UiPath.Template.SplitExcelSheet.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>UiPath.Template.SplitExcelSheet</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>SplitExcelSheetTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/SplitExcelSheet/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
+++ b/SplitExcelSheet/contentFiles/any/any/pt0/VisualBasic/GlobalHandlerX.xaml
@@ -62,6 +62,8 @@
       <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/SplitExcelSheet/contentFiles/any/any/pt0/VisualBasic/Main.xaml
+++ b/SplitExcelSheet/contentFiles/any/any/pt0/VisualBasic/Main.xaml
@@ -44,6 +44,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>

--- a/TransactionalProcess/UiPath.Template.TransactionalProcess.nuspec
+++ b/TransactionalProcess/UiPath.Template.TransactionalProcess.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>UiPath.Template.TransactionalProcess</id>
-    <version>23.4.1</version>
+    <version>24.10.0</version>
     <title>NewFlowchartProjectTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/TransactionalProcess/contentFiles/any/any/pt2/VisualBasic/Main.xaml
+++ b/TransactionalProcess/contentFiles/any/any/pt2/VisualBasic/Main.xaml
@@ -53,6 +53,8 @@
             <AssemblyReference>System.ServiceModel</AssemblyReference>
             <AssemblyReference>System.ComponentModel.Composition</AssemblyReference>
             <AssemblyReference>System.Drawing</AssemblyReference>
+            <AssemblyReference>System.Drawing.Common</AssemblyReference>
+            <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
             <AssemblyReference>UiPath.System.Activities</AssemblyReference>
             <AssemblyReference>UiPath.UiAutomation.Activities</AssemblyReference>
         </sco:Collection>

--- a/TransactionalProcess/contentFiles/any/any/pt3/CSharp/Main.xaml
+++ b/TransactionalProcess/contentFiles/any/any/pt3/CSharp/Main.xaml
@@ -44,6 +44,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Linq</AssemblyReference>
       <AssemblyReference>System.Data.Common</AssemblyReference>

--- a/TriggerBasedAttendedAutomation/UiPath.Template.TriggerBasedAttendedAutomation.nuspec
+++ b/TriggerBasedAttendedAutomation/UiPath.Template.TriggerBasedAttendedAutomation.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>UiPath.Template.TriggerBasedAttendedAutomation</id>
-    <version>23.8.0</version>
+    <version>24.10.0</version>
     <title>NewTriggerBasedAttendedAutomationTemplateTitle</title>
     <authors>UiPath</authors>
     <owners>UiPath</owners>

--- a/TriggerBasedAttendedAutomation/contentFiles/any/any/pt2/VisualBasic/Main.xaml
+++ b/TriggerBasedAttendedAutomation/contentFiles/any/any/pt2/VisualBasic/Main.xaml
@@ -45,6 +45,8 @@
       <AssemblyReference>PresentationCore</AssemblyReference>
       <AssemblyReference>System.Xaml</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>UiPath.System.Activities</AssemblyReference>
       <AssemblyReference>UiPath.UiAutomation.Activities</AssemblyReference>
       <AssemblyReference>UiPath.System.Activities.Design</AssemblyReference>

--- a/TriggerBasedAttendedAutomation/contentFiles/any/any/pt3/CSharp/Main.xaml
+++ b/TriggerBasedAttendedAutomation/contentFiles/any/any/pt3/CSharp/Main.xaml
@@ -50,6 +50,8 @@
       <AssemblyReference>System.Data</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
       <AssemblyReference>System.Core</AssemblyReference>
       <AssemblyReference>System.Xml</AssemblyReference>
       <AssemblyReference>System.Xml.Linq</AssemblyReference>


### PR DESCRIPTION
In netcore, some types from `System.Drawing` have been moved to `System.Drawing.Common` and `System.Drawing.Primitives`. Added this two AssemblyReferences to all bundled templates that target Windows and Cross-platform.
### Affected templates
- [x] AddChartToPowerPointPresentationFromExcel
- [x] AttendedAutomationFramework
- [x] BackgroundProcess
- [x] CompleteWordTemplatefromExcelandEmail
- [x] CreatePowerPointPresentation
- [x] CreateRichHtmlEmail
- [x] CrossBrowserTesting
- [x] DownloadFile
- [x] EnterExcelDataIntoWebsite
- [x] MobileTestingProject
- [x] OrchestrationProcess
- [x] SaveDesktopOutlookEmailAttachmentsToSharepointOrOneDrive
- [x] SaveGMailAttachmentsToGoogleDrive
- [x] SaveOutlook365AttachmentsToSharepointorOneDrive
- [x] SaveOutlookAttachments
- [x] SplitExcelSheet
- [x] TransactionalProcess
- [x] TriggerBasedAttendedAutomation