### PR TITLE
Remove pt2 (cross-platform) from files to exclude

### DIFF
--- a/DocumentUnderstandingProcess/UiPath.Template.DocumentUnderstandingProcess.nuspec
+++ b/DocumentUnderstandingProcess/UiPath.Template.DocumentUnderstandingProcess.nuspec
@@ -16,6 +16,6 @@
     <tags>VisualBasic VB C# UiPathStudioProcess UiPathStudioTemplate DocumentUnderstanding DocumentUnderstandingProcess</tags>
   </metadata>
   <files>
-	<file src="**" exclude="Tests\**;contentFiles\any\any\pt1\**;contentFiles\any\any\pt2\**" />
+	<file src="**" exclude="Tests\**;contentFiles\any\any\pt1\**" />
   </files>
 </package>


### PR DESCRIPTION
Remove the pt2 (cross-platform) package from files to exclude in *.nuspec