### PR TITLE
[Fix] AutomationTracker. The Service is not enabled. 

### DIFF
--- a/DocumentUnderstandingProcess/contentFiles/any/any/pt0/.local/template.json
+++ b/DocumentUnderstandingProcess/contentFiles/any/any/pt0/.local/template.json
@@ -2,12 +2,12 @@
   "DefaultProjectDescription": "New Document Understanding Process",
   "DefaultProjectName": "DocumentUnderstandingProcess",
   "Dependencies": {
-    "UiPath.DocumentUnderstanding.ML.Activities": "[1.31.1]",
-    "UiPath.Excel.Activities": "[2.24.3]",
-    "UiPath.IntelligentOCR.Activities": "[6.22.0]",
-    "UiPath.System.Activities": "[24.10.6]",
-    "UiPath.Testing.Activities": "[24.10.3]",
-    "UiPath.UIAutomation.Activities": "[24.10.7]"
+    "UiPath.DocumentUnderstanding.ML.Activities": "[1.31.2]",
+    "UiPath.Excel.Activities": "[2.24.4]",
+    "UiPath.IntelligentOCR.Activities": "[6.22.1]",
+    "UiPath.System.Activities": "[24.10.7]",
+    "UiPath.Testing.Activities": "[24.10.4]",
+    "UiPath.UIAutomation.Activities": "[24.10.11]"
   },
   "Description": "Create a business process that follows best practices for large scale deployments of Document Processing Use Cases",
   "DisplayPriority": 0,

--- a/DocumentUnderstandingProcess/contentFiles/any/any/pt0/VisualBasic/project.json
+++ b/DocumentUnderstandingProcess/contentFiles/any/any/pt0/VisualBasic/project.json
@@ -4,12 +4,12 @@
   "description": "Create a business process that follows best practices for large scale deployments of Document Processing Use Cases using VB",
   "main": "Main-ActionCenter.xaml",
   "dependencies": {
-    "UiPath.DocumentUnderstanding.ML.Activities": "[1.31.1]",
-    "UiPath.Excel.Activities": "[2.24.3]",
-    "UiPath.IntelligentOCR.Activities": "[6.22.0]",
-    "UiPath.System.Activities": "[24.10.6]",
-    "UiPath.Testing.Activities": "[24.10.3]",
-    "UiPath.UIAutomation.Activities": "[24.10.7]"
+    "UiPath.DocumentUnderstanding.ML.Activities": "[1.31.2]",
+    "UiPath.Excel.Activities": "[2.24.4]",
+    "UiPath.IntelligentOCR.Activities": "[6.22.1]",
+    "UiPath.System.Activities": "[24.10.7]",
+    "UiPath.Testing.Activities": "[24.10.4]",
+    "UiPath.UIAutomation.Activities": "[24.10.11]"
   },
   "webServices": [],
   "entitiesStores": [],


### PR DESCRIPTION
Fixed an issue caused by System Activities 24.10.6 - whenever an invoke workflow would exit, on specific versions of Studio (tested on 23.10.6, can't reproduce on newer versions),the log "[AutomationTracker] The service is not enabled" would appear and the run would stop.

With this fix I also updated the other packages for Windows. 

@alexandru-luca / @TeodoraPatrascu  - while this is a minor issue, maybe a patch version should be made (24.10.2?) to fix this rare issue and the other fixes we have in the develop branch but not yet pushed. 